### PR TITLE
Inventory: user not required when permission is inventory manager

### DIFF
--- a/app/Http/Livewire/Inventory/RegisterInventory.php
+++ b/app/Http/Livewire/Inventory/RegisterInventory.php
@@ -134,13 +134,10 @@ class RegisterInventory extends Component
     {
 		/** Si es responsable o (usuario y responsable) */
         if($this->type == 2 || $this->type == 3)
-		{
 			$reception_confirmation = true;
-		}
         else
-		{
             $reception_confirmation = false;
-		}
+
         return $reception_confirmation;
     }
 
@@ -185,9 +182,10 @@ class RegisterInventory extends Component
             'place_id' => $dataValidated['place_id'],
             'user_responsible_ou_id' => optional($responsibleUser->organizationalUnit)->id,
             'user_responsible_id' => $dataValidated['user_responsible_id'],
-            'user_using_ou_id' => optional($usingUser->organizationalUnit)->id,
+            'user_using_ou_id' => ($usingUser != null) ? optional($usingUser->organizationalUnit)->id : null,
             'user_using_id' => $dataValidated['user_using_id'],
-            'reception_confirmation' => $this->getReceptionConfirmation()
+            'reception_confirmation' => $this->getReceptionConfirmation(),
+            'reception_date' => $this->getReceptionConfirmation() ? now() : null,
         ]);
 
 		/** Enviar notificación al responsable, sólo si necesita confimación */

--- a/app/Http/Livewire/Inventory/RegisterMovement.php
+++ b/app/Http/Livewire/Inventory/RegisterMovement.php
@@ -51,9 +51,10 @@ class RegisterMovement extends Component
         $dataValidated = $this->validate();
         $userResponsible = User::find($dataValidated['user_responsible_id']);
         $userUsing = User::find($dataValidated['user_using_id']);
-
         $dataValidated['user_responsible_ou_id'] = optional($userResponsible->organizationalUnit)->id;
-        $dataValidated['user_using_ou_id'] = optional($userUsing->organizationalUnit)->id;
+
+        if($userUsing)
+            $dataValidated['user_using_ou_id'] = optional($userUsing->organizationalUnit)->id;
 
         $movements = InventoryMovement::create($dataValidated);
         $this->inventory->movements()->save($movements);

--- a/app/Http/Middleware/Warehouse/EnsureStore.php
+++ b/app/Http/Middleware/Warehouse/EnsureStore.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware\Warehouse;
 
+use App\User;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -19,11 +20,9 @@ class EnsureStore
     {
         $store = $request->route('store');
         $stores = Auth::user()->stores;
+        $user = User::find(Auth::id());
 
-        $roles = Auth::user()->getRoleNames();
-        $role = 'Store: Super admin';
-
-        if($stores->contains($store->id) || $roles->contains($role))
+        if($stores->contains($store->id) || $user->hasPermissionTo('Store: warehouse manager'))
         {
             return $next($request);
         }

--- a/app/Http/Requests/Inventory/CreateMovementRequest.php
+++ b/app/Http/Requests/Inventory/CreateMovementRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Inventory;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 
 class CreateMovementRequest extends FormRequest
 {
@@ -27,7 +28,7 @@ class CreateMovementRequest extends FormRequest
             'installation_date'     => 'nullable|date_format:Y-m-d',
             'place_id'              => 'required|exists:cfg_places,id',
             'user_responsible_id'   => 'required|exists:users,id',
-            'user_using_id'         => 'nullable|exists:users,id',
+            'user_using_id'         => (Auth::user()->can('Inventory: manager')) ? 'nullable|exists:users,id' :  'required|exists:users,id',
         ];
     }
 }

--- a/app/Http/Requests/Inventory/CreateMovementRequest.php
+++ b/app/Http/Requests/Inventory/CreateMovementRequest.php
@@ -27,7 +27,7 @@ class CreateMovementRequest extends FormRequest
             'installation_date'     => 'nullable|date_format:Y-m-d',
             'place_id'              => 'required|exists:cfg_places,id',
             'user_responsible_id'   => 'required|exists:users,id',
-            'user_using_id'         => 'required|exists:users,id',
+            'user_using_id'         => 'nullable|exists:users,id',
         ];
     }
 }

--- a/app/Http/Requests/Inventory/RegisterInventoryRequest.php
+++ b/app/Http/Requests/Inventory/RegisterInventoryRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Inventory;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 
 class RegisterInventoryRequest extends FormRequest
@@ -39,7 +40,9 @@ class RegisterInventoryRequest extends FormRequest
             'serial_number'     => 'nullable|max:255',
             'status'            => 'required|max:255',
             'observations'      => 'nullable|max:255',
-            'user_using_id'         => 'required|exists:users,id',
+            'user_using_id'     => (Auth::user()->can('Inventory: manager'))
+                                    ? 'nullable|exists:users,id'
+                                    : 'required|exists:users,id',
             'user_responsible_id'   => 'required|exists:users,id',
             'place_id'              => 'required|exists:cfg_places,id',
             'request_form_id'       => 'nullable|exists:arq_request_forms,id',

--- a/database/migrations/2022_11_15_172617_add_permissions_inventory_edit.php
+++ b/database/migrations/2022_11_15_172617_add_permissions_inventory_edit.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Permission;
+
+class AddPermissionsInventoryEdit extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Permission::create([
+            'name' => 'Inventory: edit',
+            'description' => 'Permite editar el item de inventario'
+        ]);
+
+        Permission::create([
+            'name' => 'Inventory: place maintainer',
+            'description' => 'Permite acceder al mantenedor de lugares'
+        ]);
+
+        //Inventory: place maintainer
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/resources/views/inventory/nav.blade.php
+++ b/resources/views/inventory/nav.blade.php
@@ -30,7 +30,7 @@
             </a>
         </li>
     @endcan
-    @can('Inventory: pending inventory')
+    @can('Inventory: place maintainer')
         <li class="nav-item dropdown">
             <a
                 class="nav-link dropdown-toggle  {{ active('inventories.places') }}"

--- a/resources/views/layouts/partials/nav.blade.php
+++ b/resources/views/layouts/partials/nav.blade.php
@@ -171,7 +171,12 @@
                             <h6 class="dropdown-header">Bodegas</h6>
                         @endcan
 
-                        @hasanyrole('Store: admin|Store: user|Store: Super admin')
+                        @canany([
+                            'Store', 'Store: admin', 'Store: index', 'Store: list receptions',
+                            'Store: list dispatchs', 'Store: bincard report', 'Store: maintainer programs',
+                            'Store: maintainers', 'Sotore: add invoice', 'Store: create dispatch',
+                            'Store: create reception by donation', 'Store: create reception by purcharse order'
+                        ])
                             @forelse(Auth::user()->stores as $store)
                                 <a
                                     class="dropdown-item"
@@ -189,7 +194,7 @@
                                     No tiene bodegas asignadas
                                 </a>
                             @endforelse
-                        @endhasanyrole
+                        @endcanany
 
                         @can('Store: add invoice')
                             <a
@@ -200,14 +205,14 @@
                             </a>
                         @endcan
 
-                        @role('Store: Super admin')
+                        @canany(['Store: warehouse manager'])
                             <a
                                 class="dropdown-item {{ active('warehouse.stores.index') }}"
                                 href="{{ route('warehouse.stores.index') }}"
                             >
                                 <i class="fas fa-fw fa-cog"></i> Administrar bodegas
                             </a>
-                        @endrole
+                        @endcanany
 
 
                         @can('Inventory')
@@ -281,7 +286,7 @@
                         </a>
 
                         @endcan
-                        
+
                         {{--
                         <div class="dropdown-divider"></div>
                         <a class="dropdown-item {{ active('allowances.index') }}" href="{{ route('allowances.index') }}">
@@ -638,7 +643,7 @@
                                 <img src="{{ auth()->user()->gravatarUrl }}?s=30&d=mp&r=g" class="rounded-circle" alt="{{ Auth::user()->firstName }}">
                             @else
                                 {{ Auth::user()->firstName }}
-                            @endif    
+                            @endif
                          <span class="caret"></span>
                             @if(auth()->user()->absent)
                                 <i class="fas text-warning fa-cocktail"></i>

--- a/resources/views/livewire/inventory/assigned-products.blade.php
+++ b/resources/views/livewire/inventory/assigned-products.blade.php
@@ -104,7 +104,7 @@
                     <td class="text-center" nowrap>
                         <a
                             class="btn btn-sm btn-outline-primary"
-                            href="{{ route('inventories.create-transfer', $inventory)}}"
+                            href="{{ route('inventories.create-transfer', $inventory) }}"
                         >
                             <i class="fas fa-sync-alt"></i>
                             Traspaso

--- a/resources/views/livewire/inventory/inventory-index.blade.php
+++ b/resources/views/livewire/inventory/inventory-index.blade.php
@@ -141,7 +141,7 @@
             </tr>
         </table>
     </div>
-    
+
 
     @if($place)
     <table class="mb-3 d-none d-print-block" align="right">
@@ -155,7 +155,7 @@
         </tr>
         <tr>
             <td>Fecha: &nbsp;</td>
-            <td class="font-weight-bold"> 
+            <td class="font-weight-bold">
             {{ now()->format('M Y') }}
             </td>
         </tr>
@@ -165,7 +165,7 @@
     <h3 class="mt-3">
         Inventario
     </h3>
-    
+
     @if($place)
     <table class="table table-sm table-bordered">
         <tr>
@@ -256,7 +256,7 @@
                     </td>
                     <td class="text-center d-print-none">
                         <a
-                            class="btn btn-sm btn-primary"
+                            class="btn btn-sm btn-primary @cannot('Inventory: edit') disabled @endcannot"
                             href="{{ route('inventories.edit', $inventory) }}"
                         >
                             <i class="fas fa-edit"></i>

--- a/resources/views/livewire/inventory/inventory-pending.blade.php
+++ b/resources/views/livewire/inventory/inventory-pending.blade.php
@@ -85,7 +85,7 @@
                         </td>
                         <td class="text-center">
                             <a
-                                class="btn btn-sm btn-primary"
+                                class="btn btn-sm btn-primary @cannot('Inventory: edit') disabled @endcannot"
                                 href="{{ route('inventories.edit', $inventory) }}"
                             >
                                 <i class="fas fa-edit"></i>

--- a/resources/views/livewire/inventory/movement-index.blade.php
+++ b/resources/views/livewire/inventory/movement-index.blade.php
@@ -48,15 +48,17 @@
                 </li>
             @endif
 
-            <li>
-                {{ $movement->created_at->format('Y-m-d') }}
-                - Usado por
-                <b>{{ $movement->usingUser->full_name }}</b>
-                en
-                <b>{{ $movement->place->location->name }}</b>
-                -
-                <b>{{ $movement->place->name }}</b>
-            </li>
+            @if($movement->usingUser)
+                <li>
+                    {{ $movement->created_at->format('Y-m-d') }}
+                    - Usado por
+                    <b>{{ $movement->usingUser->full_name }}</b>
+                    en
+                    <b>{{ $movement->place->location->name }}</b>
+                    -
+                    <b>{{ $movement->place->name }}</b>
+                </li>
+            @endif
 
             <li>
                 {{ $movement->created_at->format('Y-m-d') }}
@@ -69,10 +71,14 @@
 
                 @if($movement->reception_confirmation)
                     <ul>
-                        <li>
-                            {{ $movement->reception_date }} - Confirmación recepción por responsable
-                            <b>{{ $movement->responsibleUser->full_name }}</b>
-                        </li>
+                        @if($movement->reception_date)
+                            <li>
+                                {{ $movement->reception_date }}
+                                - Confirmación recepción por responsable
+                                <b>{{ $movement->responsibleUser->full_name }}</b>
+                            </li>
+                        @endif
+
                         @if($movement->observations)
                             <li>
                                 {{ $movement->reception_date }}

--- a/resources/views/livewire/inventory/update-movement.blade.php
+++ b/resources/views/livewire/inventory/update-movement.blade.php
@@ -22,7 +22,7 @@
                 type="text"
                 class="form-control form-control-sm"
                 id="using"
-                value="{{ $movement->usingUser->full_name }}"
+                value="{{ optional($movement->usingUser)->full_name }}"
                 readonly
             >
         </fieldset>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1558,13 +1558,12 @@ Route::prefix('warehouse')->as('warehouse.')->middleware('auth')->group(function
 
 // Inventories
 Route::prefix('inventories')->as('inventories.')->middleware('auth')->group(function() {
-    Route::middleware(['role:Inventory: manager'])->group(function () {
-        Route::get('/', InventoryIndex::class)->name('index');
-        Route::get('last-receptions', InventoryLastReceptions::class)->name('last-receptions');
-        Route::get('pending-inventory', InventoryPending::class)->name('pending-inventory');
-        Route::get('{inventory}/edit', InventoryEdit::class)->name('edit');
-        Route::get('places', InventoryMaintainerPlaces::class)->name('places');
-    });
+    Route::get('/', InventoryIndex::class)->name('index')->middleware(['can:Inventory: index']);
+    Route::get('last-receptions', InventoryLastReceptions::class)->name('last-receptions')->middleware(['can:Inventory: last receptions']);
+    Route::get('pending-inventory', InventoryPending::class)->name('pending-inventory')->middleware(['can:Inventory: pending inventory']);
+    Route::get('{inventory}/edit', InventoryEdit::class)->name('edit')->middleware(['can:Inventory: edit']);
+    Route::get('places', InventoryMaintainerPlaces::class)->name('places')->middleware(['can:Inventory: place maintainer']);
+
     Route::get('pending-movements', PendingMovements::class)->name('pending-movements');
     Route::get('assigned-products', AssignedProducts::class)->name('assigned-products');
     Route::get('movement/{movement}/check-transfer', CheckTransfer::class)->name('check-transfer')->middleware('ensure.movement');
@@ -1965,7 +1964,7 @@ Route::prefix('rem')->as('rem.')->middleware('auth')->group(function () {
         Route::prefix('files')->as('files.')->group(function () {
             Route::get('/', [RemFileController::class, 'index'])->name('index');
             Route::get('/download/{rem_file}', [RemFileController::class, 'download'])->name('download');
-            Route::delete('/{rem_file}/destroy', [RemFileController::class, 'destroy'])->name('destroy');            
+            Route::delete('/{rem_file}/destroy', [RemFileController::class, 'destroy'])->name('destroy');
             });
 
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1533,14 +1533,14 @@ Route::prefix('unspsc')->middleware('auth')->group(function () {
 // Warehouse
 Route::prefix('warehouse')->as('warehouse.')->middleware('auth')->group(function () {
     Route::get('invoice-management', InvoiceManagement::class)->name('invoice-management');
-    Route::resource('stores', StoreController::class)->only(['index', 'create', 'edit'])->middleware(['role:Store: Super admin']);
+    Route::resource('stores', StoreController::class)->only(['index', 'create', 'edit'])->middleware(['can:Store: warehouse manager']);
 
     Route::prefix('store')->group(function () {
         Route::get('welcome', [StoreController::class, 'welcome'])->name('store.welcome');
 
         Route::prefix('{store}')->middleware('ensure.store')->group(function () {
             Route::get('active', [StoreController::class, 'activateStore'])->name('store.active');
-            Route::get('users', [StoreController::class, 'users'])->name('stores.users')->middleware('role:Store: Super admin');
+            Route::get('users', [StoreController::class, 'users'])->name('stores.users');
             Route::get('report', [StoreController::class, 'report'])->name('store.report');
             Route::get('generate-reception', [ControlController::class, 'generateReception'])->name('generate-reception');
 


### PR DESCRIPTION
**Description**
- Add Inventory: edit & Inventory: place maintainer permissions. (migrations)
- Adds the user as not required when the authenticating user has the Inventory: manager permission: In the view of register inventory and register movement.
- Update routes, middleware and nav view to work with permissions: Inventory & Warehouse.

Refers to issue #163 

